### PR TITLE
feat: add quote domain migrations and models

### DIFF
--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
+use App\Models\Company;
 use App\Models\User;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Http\RedirectResponse;
@@ -36,10 +37,15 @@ class RegisteredUserController extends Controller
             'password' => ['required', 'confirmed', Rules\Password::defaults()],
         ]);
 
+        $company = Company::create([
+            'name' => $request->name.'\'s Company',
+        ]);
+
         $user = User::create([
             'name' => $request->name,
             'email' => $request->email,
             'password' => Hash::make($request->password),
+            'company_id' => $company->id,
         ]);
 
         event(new Registered($user));

--- a/app/Models/Company.php
+++ b/app/Models/Company.php
@@ -18,4 +18,24 @@ class Company extends Model
         'bic',
         'payment_instructions',
     ];
+
+    public function users()
+    {
+        return $this->hasMany(User::class);
+    }
+
+    public function clients()
+    {
+        return $this->hasMany(Client::class);
+    }
+
+    public function quotes()
+    {
+        return $this->hasMany(Quote::class);
+    }
+
+    public function stripeAccount()
+    {
+        return $this->hasOne(StripeAccount::class);
+    }
 }

--- a/app/Models/Payment.php
+++ b/app/Models/Payment.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Payment extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'quote_id',
+        'method',
+        'amount_cents',
+        'status',
+        'reference',
+        'evidence_path',
+        'paid_at',
+    ];
+
+    protected $casts = [
+        'paid_at' => 'datetime',
+    ];
+
+    public function quote()
+    {
+        return $this->belongsTo(Quote::class);
+    }
+}

--- a/app/Models/Quote.php
+++ b/app/Models/Quote.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Models;
+
+use App\Models\Concerns\BelongsToCompany;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Quote extends Model
+{
+    use BelongsToCompany, HasFactory;
+
+    protected $fillable = [
+        'company_id',
+        'client_id',
+        'number',
+        'currency',
+        'status',
+        'public_hash',
+        'deposit_percent',
+        'payment_method',
+        'due_at',
+    ];
+
+    public function client()
+    {
+        return $this->belongsTo(Client::class);
+    }
+
+    public function versions()
+    {
+        return $this->hasMany(QuoteVersion::class);
+    }
+
+    public function acceptances()
+    {
+        return $this->hasMany(QuoteAcceptance::class);
+    }
+
+    public function payments()
+    {
+        return $this->hasMany(Payment::class);
+    }
+
+    public function events()
+    {
+        return $this->hasMany(QuoteEvent::class);
+    }
+
+    public function views()
+    {
+        return $this->hasMany(QuoteView::class);
+    }
+
+    public function reminders()
+    {
+        return $this->hasMany(Reminder::class);
+    }
+}

--- a/app/Models/QuoteAcceptance.php
+++ b/app/Models/QuoteAcceptance.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class QuoteAcceptance extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'quote_id',
+        'version',
+        'signer_name',
+        'ip',
+        'signed_at',
+        'pdf_path',
+    ];
+
+    protected $casts = [
+        'signed_at' => 'datetime',
+    ];
+
+    public function quote()
+    {
+        return $this->belongsTo(Quote::class);
+    }
+}

--- a/app/Models/QuoteEvent.php
+++ b/app/Models/QuoteEvent.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class QuoteEvent extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'quote_id',
+        'type',
+        'payload',
+    ];
+
+    protected $casts = [
+        'payload' => 'array',
+    ];
+
+    public function quote()
+    {
+        return $this->belongsTo(Quote::class);
+    }
+}

--- a/app/Models/QuoteItem.php
+++ b/app/Models/QuoteItem.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class QuoteItem extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'quote_version_id',
+        'label',
+        'qty',
+        'unit_price_cents',
+        'tax_rate',
+        'discount_percent',
+    ];
+
+    public function version()
+    {
+        return $this->belongsTo(QuoteVersion::class, 'quote_version_id');
+    }
+}

--- a/app/Models/QuoteVersion.php
+++ b/app/Models/QuoteVersion.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class QuoteVersion extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'quote_id',
+        'version',
+        'totals',
+        'render_hash',
+    ];
+
+    protected $casts = [
+        'totals' => 'array',
+    ];
+
+    public function quote()
+    {
+        return $this->belongsTo(Quote::class);
+    }
+
+    public function items()
+    {
+        return $this->hasMany(QuoteItem::class);
+    }
+}

--- a/app/Models/QuoteView.php
+++ b/app/Models/QuoteView.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class QuoteView extends Model
+{
+    use HasFactory;
+
+    protected $table = 'views';
+
+    protected $fillable = [
+        'quote_id',
+        'ip',
+        'user_agent',
+    ];
+
+    public function quote()
+    {
+        return $this->belongsTo(Quote::class);
+    }
+}

--- a/app/Models/Reminder.php
+++ b/app/Models/Reminder.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Reminder extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'quote_id',
+        'type',
+        'sent_at',
+    ];
+
+    protected $casts = [
+        'sent_at' => 'datetime',
+    ];
+
+    public function quote()
+    {
+        return $this->belongsTo(Quote::class);
+    }
+}

--- a/app/Models/StripeAccount.php
+++ b/app/Models/StripeAccount.php
@@ -6,17 +6,12 @@ use App\Models\Concerns\BelongsToCompany;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
-class Client extends Model
+class StripeAccount extends Model
 {
     use BelongsToCompany, HasFactory;
 
     protected $fillable = [
-        'name',
         'company_id',
+        'stripe_account_id',
     ];
-
-    public function quotes()
-    {
-        return $this->hasMany(Quote::class);
-    }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -6,11 +6,12 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Spatie\Permission\Traits\HasRoles;
 
 class User extends Authenticatable
 {
     /** @use HasFactory<\Database\Factories\UserFactory> */
-    use HasFactory, Notifiable;
+    use HasFactory, Notifiable, HasRoles;
 
     /**
      * The attributes that are mass assignable.

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
         "laravel/framework": "^12.0",
         "laravel/tinker": "^2.10.1",
         "spatie/laravel-medialibrary": "^11.13",
+        "spatie/laravel-permission": "^6.0",
         "tightenco/ziggy": "^2.4"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "eec95d372b8407e15735c9b6aa148c3c",
+    "content-hash": "a94ced710d9e637ba7dae4d615752e20",
     "packages": [
         {
             "name": "anourvalar/eloquent-serialize",
@@ -5665,6 +5665,89 @@
                 }
             ],
             "time": "2025-07-17T15:46:43+00:00"
+        },
+        {
+            "name": "spatie/laravel-permission",
+            "version": "6.21.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/laravel-permission.git",
+                "reference": "6a118e8855dfffcd90403aab77bbf35a03db51b3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/laravel-permission/zipball/6a118e8855dfffcd90403aab77bbf35a03db51b3",
+                "reference": "6a118e8855dfffcd90403aab77bbf35a03db51b3",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/auth": "^8.12|^9.0|^10.0|^11.0|^12.0",
+                "illuminate/container": "^8.12|^9.0|^10.0|^11.0|^12.0",
+                "illuminate/contracts": "^8.12|^9.0|^10.0|^11.0|^12.0",
+                "illuminate/database": "^8.12|^9.0|^10.0|^11.0|^12.0",
+                "php": "^8.0"
+            },
+            "require-dev": {
+                "laravel/passport": "^11.0|^12.0",
+                "laravel/pint": "^1.0",
+                "orchestra/testbench": "^6.23|^7.0|^8.0|^9.0|^10.0",
+                "phpunit/phpunit": "^9.4|^10.1|^11.5"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Spatie\\Permission\\PermissionServiceProvider"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-main": "6.x-dev",
+                    "dev-master": "6.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "Spatie\\Permission\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Permission handling for Laravel 8.0 and up",
+            "homepage": "https://github.com/spatie/laravel-permission",
+            "keywords": [
+                "acl",
+                "laravel",
+                "permission",
+                "permissions",
+                "rbac",
+                "roles",
+                "security",
+                "spatie"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/laravel-permission/issues",
+                "source": "https://github.com/spatie/laravel-permission/tree/6.21.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-07-23T16:08:05+00:00"
         },
         {
             "name": "spatie/shiki-php",
@@ -11995,12 +12078,12 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "php": "^8.2"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "plugin-api-version": "2.6.0"
 }

--- a/database/migrations/2025_08_14_085053_create_permission_tables.php
+++ b/database/migrations/2025_08_14_085053_create_permission_tables.php
@@ -1,0 +1,136 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        $teams = config('permission.teams');
+        $tableNames = config('permission.table_names');
+        $columnNames = config('permission.column_names');
+        $pivotRole = $columnNames['role_pivot_key'] ?? 'role_id';
+        $pivotPermission = $columnNames['permission_pivot_key'] ?? 'permission_id';
+
+        throw_if(empty($tableNames), new Exception('Error: config/permission.php not loaded. Run [php artisan config:clear] and try again.'));
+        throw_if($teams && empty($columnNames['team_foreign_key'] ?? null), new Exception('Error: team_foreign_key on config/permission.php not loaded. Run [php artisan config:clear] and try again.'));
+
+        Schema::create($tableNames['permissions'], static function (Blueprint $table) {
+            // $table->engine('InnoDB');
+            $table->bigIncrements('id'); // permission id
+            $table->string('name');       // For MyISAM use string('name', 225); // (or 166 for InnoDB with Redundant/Compact row format)
+            $table->string('guard_name'); // For MyISAM use string('guard_name', 25);
+            $table->timestamps();
+
+            $table->unique(['name', 'guard_name']);
+        });
+
+        Schema::create($tableNames['roles'], static function (Blueprint $table) use ($teams, $columnNames) {
+            // $table->engine('InnoDB');
+            $table->bigIncrements('id'); // role id
+            if ($teams || config('permission.testing')) { // permission.testing is a fix for sqlite testing
+                $table->unsignedBigInteger($columnNames['team_foreign_key'])->nullable();
+                $table->index($columnNames['team_foreign_key'], 'roles_team_foreign_key_index');
+            }
+            $table->string('name');       // For MyISAM use string('name', 225); // (or 166 for InnoDB with Redundant/Compact row format)
+            $table->string('guard_name'); // For MyISAM use string('guard_name', 25);
+            $table->timestamps();
+            if ($teams || config('permission.testing')) {
+                $table->unique([$columnNames['team_foreign_key'], 'name', 'guard_name']);
+            } else {
+                $table->unique(['name', 'guard_name']);
+            }
+        });
+
+        Schema::create($tableNames['model_has_permissions'], static function (Blueprint $table) use ($tableNames, $columnNames, $pivotPermission, $teams) {
+            $table->unsignedBigInteger($pivotPermission);
+
+            $table->string('model_type');
+            $table->unsignedBigInteger($columnNames['model_morph_key']);
+            $table->index([$columnNames['model_morph_key'], 'model_type'], 'model_has_permissions_model_id_model_type_index');
+
+            $table->foreign($pivotPermission)
+                ->references('id') // permission id
+                ->on($tableNames['permissions'])
+                ->onDelete('cascade');
+            if ($teams) {
+                $table->unsignedBigInteger($columnNames['team_foreign_key']);
+                $table->index($columnNames['team_foreign_key'], 'model_has_permissions_team_foreign_key_index');
+
+                $table->primary([$columnNames['team_foreign_key'], $pivotPermission, $columnNames['model_morph_key'], 'model_type'],
+                    'model_has_permissions_permission_model_type_primary');
+            } else {
+                $table->primary([$pivotPermission, $columnNames['model_morph_key'], 'model_type'],
+                    'model_has_permissions_permission_model_type_primary');
+            }
+
+        });
+
+        Schema::create($tableNames['model_has_roles'], static function (Blueprint $table) use ($tableNames, $columnNames, $pivotRole, $teams) {
+            $table->unsignedBigInteger($pivotRole);
+
+            $table->string('model_type');
+            $table->unsignedBigInteger($columnNames['model_morph_key']);
+            $table->index([$columnNames['model_morph_key'], 'model_type'], 'model_has_roles_model_id_model_type_index');
+
+            $table->foreign($pivotRole)
+                ->references('id') // role id
+                ->on($tableNames['roles'])
+                ->onDelete('cascade');
+            if ($teams) {
+                $table->unsignedBigInteger($columnNames['team_foreign_key']);
+                $table->index($columnNames['team_foreign_key'], 'model_has_roles_team_foreign_key_index');
+
+                $table->primary([$columnNames['team_foreign_key'], $pivotRole, $columnNames['model_morph_key'], 'model_type'],
+                    'model_has_roles_role_model_type_primary');
+            } else {
+                $table->primary([$pivotRole, $columnNames['model_morph_key'], 'model_type'],
+                    'model_has_roles_role_model_type_primary');
+            }
+        });
+
+        Schema::create($tableNames['role_has_permissions'], static function (Blueprint $table) use ($tableNames, $pivotRole, $pivotPermission) {
+            $table->unsignedBigInteger($pivotPermission);
+            $table->unsignedBigInteger($pivotRole);
+
+            $table->foreign($pivotPermission)
+                ->references('id') // permission id
+                ->on($tableNames['permissions'])
+                ->onDelete('cascade');
+
+            $table->foreign($pivotRole)
+                ->references('id') // role id
+                ->on($tableNames['roles'])
+                ->onDelete('cascade');
+
+            $table->primary([$pivotPermission, $pivotRole], 'role_has_permissions_permission_id_role_id_primary');
+        });
+
+        app('cache')
+            ->store(config('permission.cache.store') != 'default' ? config('permission.cache.store') : null)
+            ->forget(config('permission.cache.key'));
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        $tableNames = config('permission.table_names');
+
+        if (empty($tableNames)) {
+            throw new \Exception('Error: config/permission.php not found and defaults could not be merged. Please publish the package configuration before proceeding, or drop the tables manually.');
+        }
+
+        Schema::drop($tableNames['role_has_permissions']);
+        Schema::drop($tableNames['model_has_roles']);
+        Schema::drop($tableNames['model_has_permissions']);
+        Schema::drop($tableNames['roles']);
+        Schema::drop($tableNames['permissions']);
+    }
+};

--- a/database/migrations/2025_08_14_085059_create_quotes_table.php
+++ b/database/migrations/2025_08_14_085059_create_quotes_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('quotes', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('company_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('client_id')->constrained()->cascadeOnDelete();
+            $table->string('number');
+            $table->string('currency', 3);
+            $table->string('status');
+            $table->string('public_hash')->unique();
+            $table->unsignedInteger('deposit_percent')->nullable();
+            $table->string('payment_method')->nullable();
+            $table->timestamp('due_at')->nullable();
+            $table->timestamps();
+
+            $table->unique(['company_id', 'number']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('quotes');
+    }
+};

--- a/database/migrations/2025_08_14_085101_create_quote_versions_table.php
+++ b/database/migrations/2025_08_14_085101_create_quote_versions_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('quote_versions', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('quote_id')->constrained()->cascadeOnDelete();
+            $table->unsignedInteger('version');
+            $table->json('totals')->nullable();
+            $table->string('render_hash');
+            $table->timestamps();
+
+            $table->unique(['quote_id', 'version']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('quote_versions');
+    }
+};

--- a/database/migrations/2025_08_14_085103_create_quote_items_table.php
+++ b/database/migrations/2025_08_14_085103_create_quote_items_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('quote_items', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('quote_version_id')->constrained()->cascadeOnDelete();
+            $table->string('label');
+            $table->integer('qty');
+            $table->integer('unit_price_cents');
+            $table->unsignedInteger('tax_rate')->default(0);
+            $table->unsignedInteger('discount_percent')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('quote_items');
+    }
+};

--- a/database/migrations/2025_08_14_085105_create_quote_acceptances_table.php
+++ b/database/migrations/2025_08_14_085105_create_quote_acceptances_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('quote_acceptances', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('quote_id')->constrained()->cascadeOnDelete();
+            $table->unsignedInteger('version');
+            $table->string('signer_name');
+            $table->string('ip', 45);
+            $table->timestamp('signed_at')->nullable();
+            $table->string('pdf_path')->nullable();
+            $table->timestamps();
+
+            $table->unique(['quote_id', 'version']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('quote_acceptances');
+    }
+};

--- a/database/migrations/2025_08_14_085106_create_payments_table.php
+++ b/database/migrations/2025_08_14_085106_create_payments_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('payments', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('quote_id')->constrained()->cascadeOnDelete();
+            $table->string('method');
+            $table->integer('amount_cents');
+            $table->string('status');
+            $table->string('reference')->nullable();
+            $table->string('evidence_path')->nullable();
+            $table->timestamp('paid_at')->nullable();
+            $table->timestamps();
+
+            $table->index('quote_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('payments');
+    }
+};

--- a/database/migrations/2025_08_14_085108_create_quote_events_table.php
+++ b/database/migrations/2025_08_14_085108_create_quote_events_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('quote_events', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('quote_id')->constrained()->cascadeOnDelete();
+            $table->string('type');
+            $table->json('payload')->nullable();
+            $table->timestamps();
+
+            $table->index('quote_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('quote_events');
+    }
+};

--- a/database/migrations/2025_08_14_085110_create_views_table.php
+++ b/database/migrations/2025_08_14_085110_create_views_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('views', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('quote_id')->constrained()->cascadeOnDelete();
+            $table->string('ip', 45)->nullable();
+            $table->text('user_agent')->nullable();
+            $table->timestamps();
+
+            $table->index('quote_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('views');
+    }
+};

--- a/database/migrations/2025_08_14_085112_create_reminders_table.php
+++ b/database/migrations/2025_08_14_085112_create_reminders_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('reminders', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('quote_id')->constrained()->cascadeOnDelete();
+            $table->string('type');
+            $table->timestamp('sent_at')->nullable();
+            $table->timestamps();
+
+            $table->index('quote_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('reminders');
+    }
+};

--- a/database/migrations/2025_08_14_085114_create_stripe_accounts_table.php
+++ b/database/migrations/2025_08_14_085114_create_stripe_accounts_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('stripe_accounts', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('company_id')->constrained()->cascadeOnDelete();
+            $table->string('stripe_account_id');
+            $table->timestamps();
+
+            $table->unique('company_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('stripe_accounts');
+    }
+};

--- a/tests/Feature/DatabaseTest.php
+++ b/tests/Feature/DatabaseTest.php
@@ -1,0 +1,85 @@
+<?php
+
+use App\Models\{Company, Client, Quote, QuoteVersion, QuoteItem, QuoteAcceptance, Payment, QuoteEvent, QuoteView, Reminder, StripeAccount, User};
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Spatie\Permission\Models\Role;
+
+uses(RefreshDatabase::class);
+
+it('runs migrations and basic relations', function () {
+    $company = Company::factory()->create();
+    $client = Client::factory()->create(['company_id' => $company->id]);
+
+    $quote = Quote::create([
+        'company_id' => $company->id,
+        'client_id' => $client->id,
+        'number' => '2025-0001',
+        'currency' => 'EUR',
+        'status' => 'draft',
+        'public_hash' => Str::random(32),
+        'deposit_percent' => 20,
+        'payment_method' => 'stripe',
+        'due_at' => now()->addDays(7),
+    ]);
+
+    $version = $quote->versions()->create([
+        'version' => 1,
+        'totals' => [],
+        'render_hash' => Str::random(40),
+    ]);
+
+    $version->items()->create([
+        'label' => 'Service',
+        'qty' => 1,
+        'unit_price_cents' => 1000,
+        'tax_rate' => 20,
+    ]);
+
+    $quote->acceptances()->create([
+        'version' => 1,
+        'signer_name' => 'John',
+        'ip' => '127.0.0.1',
+        'signed_at' => now(),
+    ]);
+
+    $quote->payments()->create([
+        'method' => 'stripe',
+        'amount_cents' => 1000,
+        'status' => 'pending',
+    ]);
+
+    $quote->events()->create([
+        'type' => 'sent',
+        'payload' => [],
+    ]);
+
+    $quote->views()->create([
+        'ip' => '127.0.0.1',
+        'user_agent' => 'test',
+    ]);
+
+    $quote->reminders()->create([
+        'type' => 'first',
+        'sent_at' => now(),
+    ]);
+
+    $company->stripeAccount()->create([
+        'stripe_account_id' => 'acct_123',
+    ]);
+
+    expect($quote->client)->toBeInstanceOf(Client::class)
+        ->and($quote->versions->first()->items->first()->label)->toBe('Service')
+        ->and($quote->acceptances)->toHaveCount(1)
+        ->and($company->stripeAccount->stripe_account_id)->toBe('acct_123');
+});
+
+it('assigns roles to users', function () {
+    $company = Company::factory()->create();
+    $user = User::factory()->create(['company_id' => $company->id]);
+
+    $role = Role::create(['name' => 'owner']);
+    $user->assignRole('owner');
+
+    expect($user->hasRole('owner'))->toBeTrue();
+});


### PR DESCRIPTION
## Summary
- add migrations for quotes, versions, items, acceptances, payments, events, views, reminders, stripe accounts and RBAC
- implement corresponding Eloquent models and relations
- cover basic migration execution and RBAC with tests

## Testing
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_689da2bfbcf88333aa33a2eb6a978fb6