### PR TITLE
Add RBAC roles and permission testing

### DIFF
--- a/app/Http/Controllers/ClientController.php
+++ b/app/Http/Controllers/ClientController.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Client;
+use Illuminate\Http\Request;
+
+class ClientController extends Controller
+{
+    public function index(Request $request)
+    {
+        return response()->json(
+            Client::where('company_id', $request->user()->company_id)->get()
+        );
+    }
+
+    public function store(Request $request)
+    {
+        $client = Client::create([
+            'name' => $request->input('name'),
+            'company_id' => $request->user()->company_id,
+        ]);
+
+        return response()->json($client, 201);
+    }
+
+    public function destroy(Request $request, Client $client)
+    {
+        $client->delete();
+
+        return response()->noContent();
+    }
+}

--- a/app/Http/Controllers/QuoteController.php
+++ b/app/Http/Controllers/QuoteController.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Quote;
+use Illuminate\Http\Request;
+
+class QuoteController extends Controller
+{
+    public function index(Request $request)
+    {
+        return response()->json(
+            Quote::where('company_id', $request->user()->company_id)->get()
+        );
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'client_id' => ['required', 'exists:clients,id'],
+            'number' => ['required', 'string'],
+            'currency' => ['required', 'string', 'size:3'],
+            'status' => ['required', 'string'],
+            'public_hash' => ['required', 'string'],
+        ]);
+
+        $data['company_id'] = $request->user()->company_id;
+
+        $quote = Quote::create($data);
+
+        return response()->json($quote, 201);
+    }
+
+    public function destroy(Request $request, Quote $quote)
+    {
+        $quote->delete();
+
+        return response()->noContent();
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -7,6 +7,9 @@ use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
 use Illuminate\Http\Middleware\AddLinkHeadersForPreloadedAssets;
+use Spatie\Permission\Middleware\PermissionMiddleware;
+use Spatie\Permission\Middleware\RoleMiddleware;
+use Spatie\Permission\Middleware\RoleOrPermissionMiddleware;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
@@ -16,6 +19,12 @@ return Application::configure(basePath: dirname(__DIR__))
     )
     ->withMiddleware(function (Middleware $middleware) {
         $middleware->encryptCookies(except: ['appearance', 'sidebar_state']);
+
+        $middleware->alias([
+            'role' => RoleMiddleware::class,
+            'permission' => PermissionMiddleware::class,
+            'role_or_permission' => RoleOrPermissionMiddleware::class,
+        ]);
 
         $middleware->web(append: [
             HandleAppearance::class,

--- a/config/permission.php
+++ b/config/permission.php
@@ -1,0 +1,202 @@
+<?php
+
+return [
+
+    'models' => [
+
+        /*
+         * When using the "HasPermissions" trait from this package, we need to know which
+         * Eloquent model should be used to retrieve your permissions. Of course, it
+         * is often just the "Permission" model but you may use whatever you like.
+         *
+         * The model you want to use as a Permission model needs to implement the
+         * `Spatie\Permission\Contracts\Permission` contract.
+         */
+
+        'permission' => Spatie\Permission\Models\Permission::class,
+
+        /*
+         * When using the "HasRoles" trait from this package, we need to know which
+         * Eloquent model should be used to retrieve your roles. Of course, it
+         * is often just the "Role" model but you may use whatever you like.
+         *
+         * The model you want to use as a Role model needs to implement the
+         * `Spatie\Permission\Contracts\Role` contract.
+         */
+
+        'role' => Spatie\Permission\Models\Role::class,
+
+    ],
+
+    'table_names' => [
+
+        /*
+         * When using the "HasRoles" trait from this package, we need to know which
+         * table should be used to retrieve your roles. We have chosen a basic
+         * default value but you may easily change it to any table you like.
+         */
+
+        'roles' => 'roles',
+
+        /*
+         * When using the "HasPermissions" trait from this package, we need to know which
+         * table should be used to retrieve your permissions. We have chosen a basic
+         * default value but you may easily change it to any table you like.
+         */
+
+        'permissions' => 'permissions',
+
+        /*
+         * When using the "HasPermissions" trait from this package, we need to know which
+         * table should be used to retrieve your models permissions. We have chosen a
+         * basic default value but you may easily change it to any table you like.
+         */
+
+        'model_has_permissions' => 'model_has_permissions',
+
+        /*
+         * When using the "HasRoles" trait from this package, we need to know which
+         * table should be used to retrieve your models roles. We have chosen a
+         * basic default value but you may easily change it to any table you like.
+         */
+
+        'model_has_roles' => 'model_has_roles',
+
+        /*
+         * When using the "HasRoles" trait from this package, we need to know which
+         * table should be used to retrieve your roles permissions. We have chosen a
+         * basic default value but you may easily change it to any table you like.
+         */
+
+        'role_has_permissions' => 'role_has_permissions',
+    ],
+
+    'column_names' => [
+        /*
+         * Change this if you want to name the related pivots other than defaults
+         */
+        'role_pivot_key' => null, // default 'role_id',
+        'permission_pivot_key' => null, // default 'permission_id',
+
+        /*
+         * Change this if you want to name the related model primary key other than
+         * `model_id`.
+         *
+         * For example, this would be nice if your primary keys are all UUIDs. In
+         * that case, name this `model_uuid`.
+         */
+
+        'model_morph_key' => 'model_id',
+
+        /*
+         * Change this if you want to use the teams feature and your related model's
+         * foreign key is other than `team_id`.
+         */
+
+        'team_foreign_key' => 'team_id',
+    ],
+
+    /*
+     * When set to true, the method for checking permissions will be registered on the gate.
+     * Set this to false if you want to implement custom logic for checking permissions.
+     */
+
+    'register_permission_check_method' => true,
+
+    /*
+     * When set to true, Laravel\Octane\Events\OperationTerminated event listener will be registered
+     * this will refresh permissions on every TickTerminated, TaskTerminated and RequestTerminated
+     * NOTE: This should not be needed in most cases, but an Octane/Vapor combination benefited from it.
+     */
+    'register_octane_reset_listener' => false,
+
+    /*
+     * Events will fire when a role or permission is assigned/unassigned:
+     * \Spatie\Permission\Events\RoleAttached
+     * \Spatie\Permission\Events\RoleDetached
+     * \Spatie\Permission\Events\PermissionAttached
+     * \Spatie\Permission\Events\PermissionDetached
+     *
+     * To enable, set to true, and then create listeners to watch these events.
+     */
+    'events_enabled' => false,
+
+    /*
+     * Teams Feature.
+     * When set to true the package implements teams using the 'team_foreign_key'.
+     * If you want the migrations to register the 'team_foreign_key', you must
+     * set this to true before doing the migration.
+     * If you already did the migration then you must make a new migration to also
+     * add 'team_foreign_key' to 'roles', 'model_has_roles', and 'model_has_permissions'
+     * (view the latest version of this package's migration file)
+     */
+
+    'teams' => false,
+
+    /*
+     * The class to use to resolve the permissions team id
+     */
+    'team_resolver' => \Spatie\Permission\DefaultTeamResolver::class,
+
+    /*
+     * Passport Client Credentials Grant
+     * When set to true the package will use Passports Client to check permissions
+     */
+
+    'use_passport_client_credentials' => false,
+
+    /*
+     * When set to true, the required permission names are added to exception messages.
+     * This could be considered an information leak in some contexts, so the default
+     * setting is false here for optimum safety.
+     */
+
+    'display_permission_in_exception' => false,
+
+    /*
+     * When set to true, the required role names are added to exception messages.
+     * This could be considered an information leak in some contexts, so the default
+     * setting is false here for optimum safety.
+     */
+
+    'display_role_in_exception' => false,
+
+    /*
+     * By default wildcard permission lookups are disabled.
+     * See documentation to understand supported syntax.
+     */
+
+    'enable_wildcard_permission' => false,
+
+    /*
+     * The class to use for interpreting wildcard permissions.
+     * If you need to modify delimiters, override the class and specify its name here.
+     */
+    // 'wildcard_permission' => Spatie\Permission\WildcardPermission::class,
+
+    /* Cache-specific settings */
+
+    'cache' => [
+
+        /*
+         * By default all permissions are cached for 24 hours to speed up performance.
+         * When permissions or roles are updated the cache is flushed automatically.
+         */
+
+        'expiration_time' => \DateInterval::createFromDateString('24 hours'),
+
+        /*
+         * The cache key used to store all permissions.
+         */
+
+        'key' => 'spatie.permission.cache',
+
+        /*
+         * You may optionally indicate a specific cache driver to use for permission and
+         * role caching using any of the `store` drivers listed in the cache.php config
+         * file. Using 'default' here means to use the `default` set in cache.php.
+         */
+
+        'store' => 'default',
+    ],
+];

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -2,8 +2,8 @@
 
 namespace Database\Seeders;
 
+use App\Models\Company;
 use App\Models\User;
-// use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
 class DatabaseSeeder extends Seeder
@@ -13,11 +13,24 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        // User::factory(10)->create();
+        $this->call(RolePermissionSeeder::class);
 
-        User::factory()->create([
-            'name' => 'Test User',
-            'email' => 'test@example.com',
+        $company = Company::factory()->create([
+            'name' => 'Demo Company',
         ]);
+
+        $owner = User::factory()->create([
+            'name' => 'Owner User',
+            'email' => 'owner@example.com',
+            'company_id' => $company->id,
+        ]);
+        $owner->assignRole('owner');
+
+        $member = User::factory()->create([
+            'name' => 'Member User',
+            'email' => 'member@example.com',
+            'company_id' => $company->id,
+        ]);
+        $member->assignRole('member');
     }
 }

--- a/database/seeders/RolePermissionSeeder.php
+++ b/database/seeders/RolePermissionSeeder.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+
+class RolePermissionSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $permissions = [
+            'clients.create',
+            'clients.read',
+            'clients.update',
+            'clients.delete',
+            'quotes.create',
+            'quotes.read',
+            'quotes.update',
+            'quotes.delete',
+        ];
+
+        foreach ($permissions as $permission) {
+            Permission::firstOrCreate(['name' => $permission]);
+        }
+
+        $owner = Role::firstOrCreate(['name' => 'owner']);
+        $owner->givePermissionTo($permissions);
+
+        $member = Role::firstOrCreate(['name' => 'member']);
+        $member->givePermissionTo([
+            'clients.create',
+            'clients.read',
+            'clients.update',
+            'quotes.create',
+            'quotes.read',
+            'quotes.update',
+        ]);
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Http\Controllers\ClientController;
+use App\Http\Controllers\QuoteController;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
 
@@ -10,6 +12,16 @@ Route::get('/', function () {
 Route::get('dashboard', function () {
     return Inertia::render('Dashboard');
 })->middleware(['auth', 'verified'])->name('dashboard');
+
+Route::middleware('auth')->group(function () {
+    Route::get('clients', [ClientController::class, 'index'])->middleware('permission:clients.read');
+    Route::post('clients', [ClientController::class, 'store'])->middleware('permission:clients.create');
+    Route::delete('clients/{client}', [ClientController::class, 'destroy'])->middleware('permission:clients.delete');
+
+    Route::get('quotes', [QuoteController::class, 'index'])->middleware('permission:quotes.read');
+    Route::post('quotes', [QuoteController::class, 'store'])->middleware('permission:quotes.create');
+    Route::delete('quotes/{quote}', [QuoteController::class, 'destroy'])->middleware('permission:quotes.delete');
+});
 
 require __DIR__.'/settings.php';
 require __DIR__.'/auth.php';

--- a/tests/Feature/RBACTest.php
+++ b/tests/Feature/RBACTest.php
@@ -1,0 +1,65 @@
+<?php
+
+use App\Models\Client;
+use App\Models\Quote;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->seed(Database\Seeders\RolePermissionSeeder::class);
+});
+
+it('allows owner to manage clients and quotes', function () {
+    $owner = User::factory()->create();
+    $owner->assignRole('owner');
+
+    $this->actingAs($owner)
+        ->post('/clients', ['name' => 'Acme'])
+        ->assertCreated();
+
+    $client = Client::where('company_id', $owner->company_id)->first();
+
+    $this->actingAs($owner)
+        ->post('/quotes', [
+            'client_id' => $client->id,
+            'number' => 'Q-1',
+            'currency' => 'EUR',
+            'status' => 'draft',
+            'public_hash' => Str::random(10),
+        ])->assertCreated();
+});
+
+it('forbids member from deleting clients and quotes', function () {
+    $member = User::factory()->create();
+    $member->assignRole('member');
+
+    $client = Client::factory()->create(['company_id' => $member->company_id]);
+
+    $this->actingAs($member)
+        ->delete('/clients/'.$client->id)
+        ->assertForbidden();
+
+    $quote = Quote::create([
+        'company_id' => $member->company_id,
+        'client_id' => $client->id,
+        'number' => 'Q-1',
+        'currency' => 'EUR',
+        'status' => 'draft',
+        'public_hash' => Str::random(10),
+    ]);
+
+    $this->actingAs($member)
+        ->delete('/quotes/'.$quote->id)
+        ->assertForbidden();
+});
+
+it('denies access without permission', function () {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->get('/clients')
+        ->assertForbidden();
+});


### PR DESCRIPTION
## Summary
- configure Spatie permission package
- seed owner & member roles with CRUD permissions
- protect client and quote endpoints with role checks and add tests

## Testing
- `npm run build`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_689da57e62288333885431f96934b79c