### PR TITLE
Add quote utilities and payment status services with tests

### DIFF
--- a/app/Services/PaymentStatusUpdater.php
+++ b/app/Services/PaymentStatusUpdater.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Quote;
+
+class PaymentStatusUpdater
+{
+    /**
+     * Update the quote payment status based on related payments.
+     */
+    public function update(Quote $quote): void
+    {
+        $statuses = $quote->payments->pluck('status');
+
+        if ($statuses->contains('failed')) {
+            $quote->status = 'payment_failed';
+        } elseif ($statuses->contains('paid')) {
+            $quote->status = 'payment_paid';
+        } else {
+            $quote->status = 'payment_pending';
+        }
+    }
+}

--- a/app/Services/PdfRenderer.php
+++ b/app/Services/PdfRenderer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Services;
+
+use Dompdf\Dompdf;
+
+class PdfRenderer
+{
+    public function __construct(private Dompdf $dompdf)
+    {
+    }
+
+    /**
+     * Render the given HTML to a PDF binary string.
+     */
+    public function render(string $html): string
+    {
+        $this->dompdf->loadHtml($html);
+        $this->dompdf->render();
+
+        return $this->dompdf->output();
+    }
+}

--- a/app/Services/QuoteNumberingService.php
+++ b/app/Services/QuoteNumberingService.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Services;
+
+use Carbon\Carbon;
+
+class QuoteNumberingService
+{
+    /**
+     * Generate the next quote number using the {YEAR}-{SEQ} format.
+     */
+    public function generate(?string $lastNumber = null, ?Carbon $date = null): string
+    {
+        $date = $date ?? Carbon::now();
+        $year = $date->format('Y');
+
+        if ($lastNumber) {
+            [$lastYear, $lastSeq] = explode('-', $lastNumber);
+            $nextSeq = $lastYear === $year ? ((int) $lastSeq + 1) : 1;
+        } else {
+            $nextSeq = 1;
+        }
+
+        return sprintf('%s-%04d', $year, $nextSeq);
+    }
+}

--- a/app/Services/ReminderEngine.php
+++ b/app/Services/ReminderEngine.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Services;
+
+use Carbon\Carbon;
+
+class ReminderEngine
+{
+    /**
+     * Calculate reminder dates (J+2 and J+7) based on the provided date.
+     *
+     * @return array<int, Carbon>
+     */
+    public function schedule(Carbon $sentAt): array
+    {
+        return [
+            $sentAt->copy()->addDays(2),
+            $sentAt->copy()->addDays(7),
+        ];
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.2",
+        "dompdf/dompdf": "^3.1",
         "filament/filament": "^4.0",
         "inertiajs/inertia-laravel": "^2.0",
         "laravel/framework": "^12.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a94ced710d9e637ba7dae4d615752e20",
+    "content-hash": "bb6fe8ed3f0091b0fc3d4e3a90bd7663",
     "packages": [
         {
             "name": "anourvalar/eloquent-serialize",
@@ -937,6 +937,161 @@
                 }
             ],
             "time": "2024-02-05T11:56:58+00:00"
+        },
+        {
+            "name": "dompdf/dompdf",
+            "version": "v3.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dompdf/dompdf.git",
+                "reference": "a51bd7a063a65499446919286fb18b518177155a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dompdf/dompdf/zipball/a51bd7a063a65499446919286fb18b518177155a",
+                "reference": "a51bd7a063a65499446919286fb18b518177155a",
+                "shasum": ""
+            },
+            "require": {
+                "dompdf/php-font-lib": "^1.0.0",
+                "dompdf/php-svg-lib": "^1.0.0",
+                "ext-dom": "*",
+                "ext-mbstring": "*",
+                "masterminds/html5": "^2.0",
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "ext-gd": "*",
+                "ext-json": "*",
+                "ext-zip": "*",
+                "mockery/mockery": "^1.3",
+                "phpunit/phpunit": "^7.5 || ^8 || ^9 || ^10 || ^11",
+                "squizlabs/php_codesniffer": "^3.5",
+                "symfony/process": "^4.4 || ^5.4 || ^6.2 || ^7.0"
+            },
+            "suggest": {
+                "ext-gd": "Needed to process images",
+                "ext-gmagick": "Improves image processing performance",
+                "ext-imagick": "Improves image processing performance",
+                "ext-zlib": "Needed for pdf stream compression"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Dompdf\\": "src/"
+                },
+                "classmap": [
+                    "lib/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-2.1"
+            ],
+            "authors": [
+                {
+                    "name": "The Dompdf Community",
+                    "homepage": "https://github.com/dompdf/dompdf/blob/master/AUTHORS.md"
+                }
+            ],
+            "description": "DOMPDF is a CSS 2.1 compliant HTML to PDF converter",
+            "homepage": "https://github.com/dompdf/dompdf",
+            "support": {
+                "issues": "https://github.com/dompdf/dompdf/issues",
+                "source": "https://github.com/dompdf/dompdf/tree/v3.1.0"
+            },
+            "time": "2025-01-15T14:09:04+00:00"
+        },
+        {
+            "name": "dompdf/php-font-lib",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dompdf/php-font-lib.git",
+                "reference": "6137b7d4232b7f16c882c75e4ca3991dbcf6fe2d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dompdf/php-font-lib/zipball/6137b7d4232b7f16c882c75e4ca3991dbcf6fe2d",
+                "reference": "6137b7d4232b7f16c882c75e4ca3991dbcf6fe2d",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "symfony/phpunit-bridge": "^3 || ^4 || ^5 || ^6"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "FontLib\\": "src/FontLib"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-2.1-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "The FontLib Community",
+                    "homepage": "https://github.com/dompdf/php-font-lib/blob/master/AUTHORS.md"
+                }
+            ],
+            "description": "A library to read, parse, export and make subsets of different types of font files.",
+            "homepage": "https://github.com/dompdf/php-font-lib",
+            "support": {
+                "issues": "https://github.com/dompdf/php-font-lib/issues",
+                "source": "https://github.com/dompdf/php-font-lib/tree/1.0.1"
+            },
+            "time": "2024-12-02T14:37:59+00:00"
+        },
+        {
+            "name": "dompdf/php-svg-lib",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dompdf/php-svg-lib.git",
+                "reference": "eb045e518185298eb6ff8d80d0d0c6b17aecd9af"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dompdf/php-svg-lib/zipball/eb045e518185298eb6ff8d80d0d0c6b17aecd9af",
+                "reference": "eb045e518185298eb6ff8d80d0d0c6b17aecd9af",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": "^7.1 || ^8.0",
+                "sabberworm/php-css-parser": "^8.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Svg\\": "src/Svg"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "The SvgLib Community",
+                    "homepage": "https://github.com/dompdf/php-svg-lib/blob/master/AUTHORS.md"
+                }
+            ],
+            "description": "A library to read, parse and export to PDF SVG files.",
+            "homepage": "https://github.com/dompdf/php-svg-lib",
+            "support": {
+                "issues": "https://github.com/dompdf/php-svg-lib/issues",
+                "source": "https://github.com/dompdf/php-svg-lib/tree/1.0.0"
+            },
+            "time": "2024-04-29T13:26:35+00:00"
         },
         {
             "name": "dragonmantank/cron-expression",
@@ -5230,6 +5385,72 @@
                 }
             ],
             "time": "2025-02-25T09:09:36+00:00"
+        },
+        {
+            "name": "sabberworm/php-css-parser",
+            "version": "v8.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/MyIntervals/PHP-CSS-Parser.git",
+                "reference": "d8e916507b88e389e26d4ab03c904a082aa66bb9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/MyIntervals/PHP-CSS-Parser/zipball/d8e916507b88e389e26d4ab03c904a082aa66bb9",
+                "reference": "d8e916507b88e389e26d4ab03c904a082aa66bb9",
+                "shasum": ""
+            },
+            "require": {
+                "ext-iconv": "*",
+                "php": "^5.6.20 || ^7.0.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "5.7.27 || 6.5.14 || 7.5.20 || 8.5.41",
+                "rawr/cross-data-providers": "^2.0.0"
+            },
+            "suggest": {
+                "ext-mbstring": "for parsing UTF-8 CSS"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "9.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Sabberworm\\CSS\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Raphael Schweikert"
+                },
+                {
+                    "name": "Oliver Klee",
+                    "email": "github@oliverklee.de"
+                },
+                {
+                    "name": "Jake Hotson",
+                    "email": "jake.github@qzdesign.co.uk"
+                }
+            ],
+            "description": "Parser for CSS Files written in PHP",
+            "homepage": "https://www.sabberworm.com/blog/2010/6/10/php-css-parser",
+            "keywords": [
+                "css",
+                "parser",
+                "stylesheet"
+            ],
+            "support": {
+                "issues": "https://github.com/MyIntervals/PHP-CSS-Parser/issues",
+                "source": "https://github.com/MyIntervals/PHP-CSS-Parser/tree/v8.9.0"
+            },
+            "time": "2025-07-11T13:20:48+00:00"
         },
         {
             "name": "scrivo/highlight.php",

--- a/tests/Unit/PaymentStatusUpdaterTest.php
+++ b/tests/Unit/PaymentStatusUpdaterTest.php
@@ -1,0 +1,38 @@
+<?php
+
+use App\Models\Payment;
+use App\Models\Quote;
+use App\Services\PaymentStatusUpdater;
+
+it('marks quote as paid when a payment is paid', function () {
+    $quote = new Quote();
+    $quote->setRelation('payments', collect([
+        new Payment(['status' => 'paid']),
+    ]));
+
+    (new PaymentStatusUpdater())->update($quote);
+
+    expect($quote->status)->toBe('payment_paid');
+});
+
+it('marks quote as failed when a payment failed', function () {
+    $quote = new Quote();
+    $quote->setRelation('payments', collect([
+        new Payment(['status' => 'failed']),
+    ]));
+
+    (new PaymentStatusUpdater())->update($quote);
+
+    expect($quote->status)->toBe('payment_failed');
+});
+
+it('marks quote as pending when no payment', function () {
+    $quote = new Quote();
+    $quote->setRelation('payments', collect([
+        new Payment(['status' => 'pending']),
+    ]));
+
+    (new PaymentStatusUpdater())->update($quote);
+
+    expect($quote->status)->toBe('payment_pending');
+});

--- a/tests/Unit/PdfRendererTest.php
+++ b/tests/Unit/PdfRendererTest.php
@@ -1,0 +1,11 @@
+<?php
+
+use App\Services\PdfRenderer;
+use Dompdf\Dompdf;
+
+it('renders html to pdf', function () {
+    $renderer = new PdfRenderer(new Dompdf());
+    $pdf = $renderer->render('<h1>Hello</h1>');
+
+    expect($pdf)->toStartWith('%PDF');
+});

--- a/tests/Unit/QuoteNumberingServiceTest.php
+++ b/tests/Unit/QuoteNumberingServiceTest.php
@@ -1,0 +1,18 @@
+<?php
+
+use App\Services\QuoteNumberingService;
+use Carbon\Carbon;
+
+it('generates next quote number for same year', function () {
+    $service = new QuoteNumberingService();
+    $number = $service->generate('2024-0001', Carbon::create(2024, 5, 1));
+
+    expect($number)->toBe('2024-0002');
+});
+
+it('resets sequence when year changes', function () {
+    $service = new QuoteNumberingService();
+    $number = $service->generate('2024-0005', Carbon::create(2025, 1, 1));
+
+    expect($number)->toBe('2025-0001');
+});

--- a/tests/Unit/ReminderEngineTest.php
+++ b/tests/Unit/ReminderEngineTest.php
@@ -1,0 +1,12 @@
+<?php
+
+use App\Services\ReminderEngine;
+use Carbon\Carbon;
+
+it('calculates reminder dates J+2 and J+7', function () {
+    $engine = new ReminderEngine();
+    $dates = $engine->schedule(Carbon::create(2024, 4, 10));
+
+    expect($dates[0]->toDateString())->toBe('2024-04-12');
+    expect($dates[1]->toDateString())->toBe('2024-04-17');
+});


### PR DESCRIPTION
## Summary
- add quote numbering service for {YEAR}-{SEQ}
- add PDF renderer using Dompdf
- add reminder engine for J+2 and J+7 scheduling
- update quote payment status based on related payments
- include unit tests for all services

## Testing
- `php artisan test --testsuite=Unit`

------
https://chatgpt.com/codex/tasks/task_e_689dabee402c8333a5a61743003eda9f